### PR TITLE
Bug if two consecutive text tokens match the same first mandatory rule token 

### DIFF
--- a/explicit-python/__test__/test_DE_general.py
+++ b/explicit-python/__test__/test_DE_general.py
@@ -59,7 +59,7 @@ class DEGeneralTest(unittest.TestCase):
         engine = ExplicitEngine(rules)
 
         result = engine.execute("123 456 mm")
-        expected_result = [{"nn": "456", "uu": "mm"}]
+        expected_result = [{"value": "456", "unit": "mm"}]
 
         self.assertEqual(result, expected_result)
 

--- a/explicit-python/__test__/test_DE_general.py
+++ b/explicit-python/__test__/test_DE_general.py
@@ -8,7 +8,7 @@ from explicit_nlu.parser.xml.ExplicitXmlParser import ExplicitXmlParser
 class DEGeneralTest(unittest.TestCase):
     root_dir = os.path.dirname(os.path.realpath(__file__))
 
-    def test(self):
+    def test_1(self):
         # logging.basicConfig(level = logging.DEBUG)
 
         rules = ExplicitXmlParser().parse(f"{self.root_dir}/../../src/main/resources/de/general.xml")
@@ -52,6 +52,17 @@ class DEGeneralTest(unittest.TestCase):
         check = default_check.copy()
         check.update({"date1d": "6", "date2dmy": "09.04.2020."})
         self.assertEqual(result, [check])
+
+    def test_2(self):
+
+        rules = ExplicitXmlParser().parse(f"{self.root_dir}/../../src/main/resources/de/general.xml")
+        engine = ExplicitEngine(rules)
+
+        result = engine.execute("123 456 mm")
+        expected_result = [{"nn": "456", "uu": "mm"}]
+
+        self.assertEqual(result, expected_result)
+
 
     if __name__ == '__main__':
         unittest.main()

--- a/src/main/resources/de/general.xml
+++ b/src/main/resources/de/general.xml
@@ -31,7 +31,19 @@
         <dateDay>([0-2]{0,1}[0-9]|[3][0-1]\.?)</dateDay>
         <dateMonth>([0]{0,1}[0-9]|[1][0-2]\.?)</dateMonth>
         <dateYear>[0-9]{2}|[0-9]{4}|</dateYear>
+
+        <unit>(m|cm|mm)</unit>
     </patterns>
+
+    <rule>
+        <eql>
+            {number}:value {unit}:unit
+        </eql>
+        <ner>
+            <value>$value</value>
+            <unit>$unit</unit>
+        </ner>
+    </rule>
 
     <rule>
         <eql>


### PR DESCRIPTION
Test Case, der diesen Fehler illustriert. Ich habe (naiv) versucht text_nav um einen Index zurückzusetzen falls kein match mehr gefunden wird, aber dann schlagen die anderen tests in "test_DE_general" fehl. Ich komme momentan nicht dazu den Fehler zu beheben.